### PR TITLE
Add pry as development dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     diff-lcs (1.3)
+    method_source (0.9.0)
     net-ldap (0.16.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rake (12.3.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -29,6 +34,7 @@ PLATFORMS
 
 DEPENDENCIES
   ldap_groups_lookup!
+  pry
   rake
   rspec
 

--- a/ldap_groups_lookup.gemspec
+++ b/ldap_groups_lookup.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'net-ldap'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'pry'
 end


### PR DESCRIPTION
For some reason, rspec complained about missing pry after updating bundle.