### PR TITLE
Member whitelist yml configuration

### DIFF
--- a/lib/ldap_groups_lookup/configuration.rb
+++ b/lib/ldap_groups_lookup/configuration.rb
@@ -45,6 +45,10 @@ module LDAPGroupsLookup
       config[:tree]
     end
 
+    def member_filter
+      config[:member_filter].to_a
+    end
+
     private
 
     def configure(value)

--- a/lib/ldap_groups_lookup/configuration.rb
+++ b/lib/ldap_groups_lookup/configuration.rb
@@ -45,8 +45,8 @@ module LDAPGroupsLookup
       config[:tree]
     end
 
-    def member_filter
-      config[:member_filter].to_a
+    def member_whitelist
+      config[:member_whitelist].to_a
     end
 
     private

--- a/lib/ldap_groups_lookup/search.rb
+++ b/lib/ldap_groups_lookup/search.rb
@@ -57,7 +57,9 @@ module LDAPGroupsLookup
         next if seen.include? g
         seen << g
         member_groups = members.collect do |mg|
-          dn_to_cn(mg) if (mg.include?('OU=Groups') || mg.include?('OU=Applications'))
+          dn_to_cn(mg) if member_filter.empty? || member_filter.any? do |fil|
+            mg.include? fil
+          end
         end
         member_groups.compact!
         return true if walk_ldap_members(member_groups, dn, seen)

--- a/lib/ldap_groups_lookup/search.rb
+++ b/lib/ldap_groups_lookup/search.rb
@@ -57,7 +57,7 @@ module LDAPGroupsLookup
         next if seen.include? g
         seen << g
         member_groups = members.collect do |mg|
-          dn_to_cn(mg) if member_filter.empty? || member_filter.any? do |fil|
+          dn_to_cn(mg) if member_whitelist.empty? || member_whitelist.any? do |fil|
             mg.include? fil
           end
         end

--- a/spec/fixtures/ldap_groups_lookup.yml.example
+++ b/spec/fixtures/ldap_groups_lookup.yml.example
@@ -7,5 +7,5 @@
 :tree: dc=ads,dc=example,dc=net
 :account_ou: ou=Accounts
 :group_ou: ou=Groups
-:member_filter:
+:member_whitelist:
   - OU=Groups

--- a/spec/fixtures/ldap_groups_lookup.yml.example
+++ b/spec/fixtures/ldap_groups_lookup.yml.example
@@ -7,3 +7,5 @@
 :tree: dc=ads,dc=example,dc=net
 :account_ou: ou=Accounts
 :group_ou: ou=Groups
+:member_filter:
+  - OU=Groups

--- a/spec/lib/ldap_groups_lookup_spec.rb
+++ b/spec/lib/ldap_groups_lookup_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe LDAPGroupsLookup do
           end
           context 'when the group is whitelisted' do
             before do
-              allow(LDAPGroupsLookup).to receive(:member_filter).and_return(['OU=Groups'])
+              allow(LDAPGroupsLookup).to receive(:member_whitelist).and_return(['OU=Groups'])
             end
             it 'should return true' do
               expect(user.member_of_ldap_group?('Top-Group')).to eq(true)
@@ -236,7 +236,7 @@ RSpec.describe LDAPGroupsLookup do
           end
           context 'when the whitelist is empty' do
             before do
-              allow(LDAPGroupsLookup).to receive(:member_filter).and_return([])
+              allow(LDAPGroupsLookup).to receive(:member_whitelist).and_return([])
             end
             it 'should return true (whitelisting is disabled)' do
               expect(user.member_of_ldap_group?('Top-Group')).to eq(true)
@@ -244,7 +244,7 @@ RSpec.describe LDAPGroupsLookup do
           end
           context 'when the group is not whitelisted' do
             before do
-              allow(LDAPGroupsLookup).to receive(:member_filter).and_return(['OU=Not-A-Match'])
+              allow(LDAPGroupsLookup).to receive(:member_whitelist).and_return(['OU=Not-A-Match'])
             end
             it 'should return false' do
               expect(user.member_of_ldap_group?('Top-Group')).to eq(false)

--- a/spec/lib/ldap_groups_lookup_spec.rb
+++ b/spec/lib/ldap_groups_lookup_spec.rb
@@ -216,16 +216,39 @@ RSpec.describe LDAPGroupsLookup do
           end
         end
         context 'when searching for a group that user is a nested member of' do
-          it 'should return true' do
+          before do
             expect(@service).to receive(:search).with(
                 hash_including(filter: Net::LDAP::Filter.equals('cn', 'Top-Group'))).and_return([@top_group])
-            expect(@service).to receive(:search).with(
+            allow(@service).to receive(:search).with(
                 hash_including(filter: Net::LDAP::Filter.equals('cn', 'Nested-Group'),
                                attributes: ['member;range=0-*'])).and_return([@nested_group_page_1])
-            expect(@service).to receive(:search).with(
+            allow(@service).to receive(:search).with(
                 hash_including(filter: Net::LDAP::Filter.equals('cn', 'Nested-Group'),
                                attributes: ['member;range=1-*'])).and_return([@nested_group_page_2])
-            expect(user.member_of_ldap_group?('Top-Group')).to eq(true)
+          end
+          context 'when the group is whitelisted' do
+            before do
+              allow(LDAPGroupsLookup).to receive(:member_filter).and_return(['OU=Groups'])
+            end
+            it 'should return true' do
+              expect(user.member_of_ldap_group?('Top-Group')).to eq(true)
+            end
+          end
+          context 'when the whitelist is empty' do
+            before do
+              allow(LDAPGroupsLookup).to receive(:member_filter).and_return([])
+            end
+            it 'should return true (whitelisting is disabled)' do
+              expect(user.member_of_ldap_group?('Top-Group')).to eq(true)
+            end
+          end
+          context 'when the group is not whitelisted' do
+            before do
+              allow(LDAPGroupsLookup).to receive(:member_filter).and_return(['OU=Not-A-Match'])
+            end
+            it 'should return false' do
+              expect(user.member_of_ldap_group?('Top-Group')).to eq(false)
+            end
           end
         end
       end


### PR DESCRIPTION
Moves hardcoded values for membership filtering when walking the member tree to the yaml configuration file. If member_whitelist is not found in the config, then no filtering is applied.